### PR TITLE
Generate types for ${frontendConfig.app}

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install -g @codegenerator/mfe-gen
 
 ### Geração de Código Front-End
 
-Para gerar componentes, serviços, hooks, contextos e arquivos de ambiente de um projeto React, você precisa informar todos os parâmetros necessários de uma vez só. Aqui está um exemplo:
+Para gerar componentes, serviços, hooks, contextos, arquivos de ambiente, estilos e tipos de um projeto React, você precisa informar todos os parâmetros necessários de uma vez só. Aqui está um exemplo:
 
 ```bash
 npm run build && npx ts-node src/main.ts \
@@ -27,7 +27,7 @@ npm run build && npx ts-node src/main.ts \
   -H 'Authorization: Bearer XYZ' \
   -a 'MyApp' \
   -o './build' \
-  -f 'component,services,hooks,context,env,styles'
+  -f 'component,services,hooks,context,env,styles,types'
 ```
 
 ### Parâmetros Suportados

--- a/src/types-generator.ts
+++ b/src/types-generator.ts
@@ -1,14 +1,34 @@
-
 // src/types-generator.ts
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { IGenerator, DbReaderConfig, Table } from "./interfaces";
+import { IGenerator, FrontendGeneratorConfig } from "./interfaces";
 import { BaseGenerator } from "./base-generator";
 
-
 export class TypesGenerator extends BaseGenerator implements IGenerator {
+    constructor(config: FrontendGeneratorConfig) {
+        super(config);
+    }
+
     generate() {
-        // Implementação específica para gerar componentes
+        const typeName = `${this.config.app}Props`;  // Define o nome da interface baseada no nome da aplicação
+
+        // Conteúdo do arquivo types.ts
+        const typesContent = `
+export interface ${typeName} {
+    // Defina aqui as props específicas para o componente ${this.config.app}
+}
+`;
+
+        // Define o caminho para o arquivo types.ts
+        const filePath = path.join(this.config.outputDir, `components/${this.config.app}/types.ts`);
+
+        // Cria o diretório caso não exista
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+        // Escreve o conteúdo no arquivo types.ts
+        fs.writeFileSync(filePath, typesContent.trim());
+
+        console.log(`Types generated at ${filePath}`);
     }
 }


### PR DESCRIPTION
Este PR adiciona a implementação do gerador de tipos (`TypesGenerator`) ao projeto **mfe-gen**. Com esta implementação, é possível gerar automaticamente o arquivo `types.ts` para componentes React, incluindo interfaces e tipos específicos necessários para o desenvolvimento do componente.

### Alterações Incluídas:
- Implementação da classe `TypesGenerator` que gera um arquivo `types.ts` na pasta do componente especificado.
- O arquivo `types.ts` contém a interface `SistemaProps`, que pode ser estendida conforme a necessidade do componente.
- Integração completa do `TypesGenerator` com o fluxo de geração do projeto, permitindo que ele seja chamado junto com outros geradores.

### Exemplo de Uso:
Para gerar o arquivo de tipos, execute o comando:
```bash
npm run build && npx ts-node src/main.ts \
  -X 'GET' \
  -U 'https://biud-microservice-users.dev.biud.services/health' \
  -H 'accept: */*' \
  -a 'Sistema' \
  -o './build' \
  -f 'component, services, hooks, context, env, styles, types'
```

### Resultado:
- O arquivo `types.ts` será gerado na pasta do componente, com a interface básica para as props.
  
Este PR aprimora a funcionalidade do **mfe-gen**, permitindo uma melhor organização e tipagem no desenvolvimento de componentes React.
